### PR TITLE
기본적인 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.exam'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/src/main/java/com/exam/tomatoback/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/exam/tomatoback/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.exam.tomatoback.infrastructure.exception;
+
+import com.exam.tomatoback.web.dto.common.CommonResponse;
+import com.exam.tomatoback.web.dto.common.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+ @ExceptionHandler(TomatoException.class)
+ public ResponseEntity<?> tomatoExceptionHandler(TomatoException e) {
+  log.error(e.getMessage());
+  return ResponseEntity.status(e.getStatus()).body(CommonResponse.fail(ExceptionResponse.setMessage(e.getStatus(),e.getCode(), e.getMessage())));
+ }
+}

--- a/src/main/java/com/exam/tomatoback/infrastructure/exception/TomatoException.java
+++ b/src/main/java/com/exam/tomatoback/infrastructure/exception/TomatoException.java
@@ -1,0 +1,17 @@
+package com.exam.tomatoback.infrastructure.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class TomatoException extends RuntimeException{
+ private final HttpStatus status;
+ private final String code;
+ private final String message;
+
+ public TomatoException(TomatoExceptionCode code) {
+  this.code = code.getCode();
+  this.status = code.getStatus();
+  this.message = code.getMessage();
+ }
+}

--- a/src/main/java/com/exam/tomatoback/infrastructure/exception/TomatoExceptionCode.java
+++ b/src/main/java/com/exam/tomatoback/infrastructure/exception/TomatoExceptionCode.java
@@ -1,0 +1,19 @@
+package com.exam.tomatoback.infrastructure.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TomatoExceptionCode {
+ INTERNAL_SERVER_ERROR(
+     HttpStatus.INTERNAL_SERVER_ERROR,
+     "TOMATO_000",
+     "알 수 없는 서버 에러가 발생하였습니다."
+ );
+
+ private HttpStatus status;
+ private String code;
+ private String message;
+}

--- a/src/main/java/com/exam/tomatoback/web/dto/common/CommonResponse.java
+++ b/src/main/java/com/exam/tomatoback/web/dto/common/CommonResponse.java
@@ -1,0 +1,48 @@
+package com.exam.tomatoback.web.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+/**
+ * 요청에 대한 응답을 구조화하는 공통 DTO 클래스입니다.
+ *
+ * <p>이 클래스는 요청 성공 여부와 관련 데이터를 포함한 응답 객체를 제공합니다.
+ * 제네릭 타입을 사용하여 다양한 데이터 타입을 처리할 수 있습니다.</p>
+ *
+ * @param <T> 응답 데이터의 타입
+ * @param success 요청이 성공했는지 여부를 나타내는 플래그
+ * @param data 요청에 대한 실제 응답 데이터
+ * @param error 에러가 발생할 경우 받는 데이터
+ *
+ * @version 1.0
+ * @since 2024-07-30
+ * @author namung08
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CommonResponse<T>(Boolean success, T data, ExceptionResponse error) {
+ /**
+  * 성공적인 응답을 생성하는 정적 메서드입니다.
+  *
+  * <p>이 메서드는 주어진 데이터를 포함한 성공적인 응답 객체를 생성합니다.</p>
+  *
+  * @param <T> 응답 데이터의 타입
+  * @param data 응답에 포함할 데이터
+  * @return 성공 플래그가 {@code true}인 {@code CommonResponse} 객체
+  */
+ public static <T> CommonResponse<T> success(T data) {
+  return new CommonResponse<>(true, data, null);
+ }
+
+ /**
+  * 실패한 응답을 생성하는 정적 메서드입니다.
+  *
+  * <p>이 메서드는 주어진 데이터를 포함한 실패한 응답 객체를 생성합니다.</p>
+  *
+  * @param <T> 응답 데이터의 타입
+  * @param error 실패에 대한 정보를 담은 데이터
+  * @return 성공 플래그가 {@code false}인 {@code CommonResponse} 객체
+  */
+ public static <T> CommonResponse<T> fail(ExceptionResponse error) {
+  return new CommonResponse<>(false, null, error);
+ }
+}

--- a/src/main/java/com/exam/tomatoback/web/dto/common/ExceptionResponse.java
+++ b/src/main/java/com/exam/tomatoback/web/dto/common/ExceptionResponse.java
@@ -1,0 +1,11 @@
+package com.exam.tomatoback.web.dto.common;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ExceptionResponse(
+    HttpStatus status,
+    String code,
+    String message
+) {}

--- a/src/main/java/com/exam/tomatoback/web/dto/common/ExceptionResponse.java
+++ b/src/main/java/com/exam/tomatoback/web/dto/common/ExceptionResponse.java
@@ -5,7 +5,15 @@ import org.springframework.http.HttpStatus;
 
 @Builder
 public record ExceptionResponse(
-    HttpStatus status,
+    int status,
     String code,
     String message
-) {}
+) {
+ public static ExceptionResponse setMessage(HttpStatus status, String code, String message) {
+  return ExceptionResponse.builder()
+      .status(status.value())
+      .code(code)
+      .message(message)
+      .build();
+ }
+}


### PR DESCRIPTION
서버에서 프론트로 데이터를 전송 시 보내질 json 데이터의 형식을 지정하였으며 tomato 서버에서 사용할 전역 에러를 담당하는 코드를 만들었습니다.

사용 법의 경우 일반적으로 컨트롤러에서 사용을 하시게 될 텐데

```java
import com.exam.tomatoback.web.dto.common.CommonResponse;
import org.springframework.http.HttpStatus;
import org.springframework.http.ResponseEntity;

public ResponseEntity<?> getblahblah(String blah) {
    return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success("성공"));
}
```
이런 식으로 사용을 하면 됩니다.

또한 에러를 넘길 경우

```java
import com.exam.tomatoback.infrastructure.exception.TomatoException;
import com.exam.tomatoback.infrastructure.exception.TomatoExceptionCode;

public void throwExam() {
    throw new TomatoException(TomatoExceptionCode.INTERNAL_SERVER_ERROR);
}
```

위와 같은 방식으로 넘길 경우 GlobalExceptionHandler 에서 처리를 할 수 있습니다.